### PR TITLE
feat: show margin and padding to the property details view

### DIFF
--- a/inspector-runtime/src/main/java/com/uhufor/inspector/engine/ComposeHitTester.kt
+++ b/inspector-runtime/src/main/java/com/uhufor/inspector/engine/ComposeHitTester.kt
@@ -1,7 +1,6 @@
 package com.uhufor.inspector.engine
 
 import android.annotation.SuppressLint
-import android.graphics.Color
 import android.graphics.RectF
 import android.util.Size
 import android.view.View
@@ -130,7 +129,9 @@ internal object ComposeHitTester {
             type = UiNodeType.COMPOSE,
             id = id.toString(),
             size = layoutInfo.run { Size(width, height) },
-            margin = marginBetweenParent(),
+            distance = getDistanceFromParent(),
+            margin = RectF(),
+            padding = RectF(),
             actions = buildSet {
                 if (config.getOrNull(SemanticsActions.OnClick) != null) {
                     add(UiNodeActionProperties.CLICKABLE)
@@ -163,7 +164,7 @@ internal object ComposeHitTester {
             }
         )
 
-    private fun SemanticsNode.marginBetweenParent(): RectF {
+    private fun SemanticsNode.getDistanceFromParent(): RectF {
         val parentBounds = parent?.boundsInWindow ?: return RectF()
         val childBounds = boundsInWindow
 

--- a/inspector-runtime/src/main/java/com/uhufor/inspector/engine/InspectorEngine.kt
+++ b/inspector-runtime/src/main/java/com/uhufor/inspector/engine/InspectorEngine.kt
@@ -222,7 +222,7 @@ internal class InspectorEngine(
         return primarySelection?.run {
             copy(
                 properties = properties.copy(
-                    margin = RelativeMeasurement.getRelativeBounds(primary, secondary)
+                    distance = RelativeMeasurement.getRelativeBounds(primary, secondary)
                 )
             )
         }

--- a/inspector-runtime/src/main/java/com/uhufor/inspector/engine/SelectionState.kt
+++ b/inspector-runtime/src/main/java/com/uhufor/inspector/engine/SelectionState.kt
@@ -1,8 +1,6 @@
 package com.uhufor.inspector.engine
 
-import android.graphics.Color
 import android.graphics.RectF
-import android.graphics.Typeface
 import android.util.Size
 
 internal data class SelectionState(
@@ -44,7 +42,9 @@ internal data class UiNodeProperties(
     val type: UiNodeType,
     val id: String,
     val size: Size,
+    val distance: RectF,
     val margin: RectF,
+    val padding: RectF,
     val actions: Set<UiNodeActionProperties> = emptySet(),
     val styles: Set<UiNodeStyleProperties> = emptySet(),
 ) {

--- a/inspector-runtime/src/main/java/com/uhufor/inspector/engine/ViewHitTester.kt
+++ b/inspector-runtime/src/main/java/com/uhufor/inspector/engine/ViewHitTester.kt
@@ -3,6 +3,7 @@ package com.uhufor.inspector.engine
 import android.graphics.Rect
 import android.graphics.RectF
 import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.GradientDrawable
 import android.graphics.drawable.RippleDrawable
 import android.os.Build
 import android.util.Size
@@ -10,6 +11,10 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Checkable
 import android.widget.TextView
+import androidx.core.view.marginBottom
+import androidx.core.view.marginLeft
+import androidx.core.view.marginRight
+import androidx.core.view.marginTop
 
 internal object ViewHitTester {
     private const val MIN_VIEW_SIZE = 1
@@ -112,7 +117,9 @@ internal object ViewHitTester {
                 type = UiNodeType.VIEW,
                 id = getResourceId(view),
                 size = Size(view.width, view.height),
-                margin = view.marginBetweenParent(),
+                distance = view.getDistanceFromParent(),
+                margin = view.getMargin(),
+                padding = view.getPadding(),
                 actions = buildSet {
                     if (view.isClickable) {
                         add(UiNodeActionProperties.CLICKABLE)
@@ -155,6 +162,10 @@ internal object ViewHitTester {
                                     }
                                 }
 
+                                is GradientDrawable -> {
+                                    drawable.color?.defaultColor
+                                }
+
                                 else -> {
                                     null
                                 }
@@ -181,7 +192,8 @@ internal object ViewHitTester {
         }.getOrDefault(NO_ID)
     }
 
-    private fun View.marginBetweenParent(): RectF {
+    // TODO: change name to distance
+    private fun View.getDistanceFromParent(): RectF {
         val parent = parent as? View ?: return RectF()
 
         val viewLocation = IntArray(2)
@@ -205,6 +217,24 @@ internal object ViewHitTester {
             (viewTop - parentTop).toFloat(),
             (parentRight - viewRight).toFloat(),
             (parentBottom - viewBottom).toFloat()
+        )
+    }
+
+    private fun View.getMargin(): RectF {
+        return RectF(
+            marginLeft.toFloat(),
+            marginTop.toFloat(),
+            marginRight.toFloat(),
+            marginBottom.toFloat()
+        )
+    }
+
+    private fun View.getPadding(): RectF {
+        return RectF(
+            paddingLeft.toFloat(),
+            paddingTop.toFloat(),
+            paddingRight.toFloat(),
+            paddingBottom.toFloat()
         )
     }
 }

--- a/inspector-runtime/src/main/java/com/uhufor/inspector/ui/ElementDetails.kt
+++ b/inspector-runtime/src/main/java/com/uhufor/inspector/ui/ElementDetails.kt
@@ -91,7 +91,7 @@ internal fun ElementDetails(
             InfoRow("Size", size)
 
             Measurement(selectionState, unitMode)
-            BoxModel(selectionState, unitMode)
+            MarginPadding(selectionState, unitMode)
             Actions(selectionState)
             Styles(selectionState)
         }
@@ -166,8 +166,8 @@ private fun Measurement(
         }
     }
 
-    val margin = remember(selectionState.properties.margin, unitMode) {
-        val margin = selectionState.properties.margin
+    val margin = remember(selectionState.properties.distance, unitMode) {
+        val margin = selectionState.properties.distance
         buildList {
             when (unitMode) {
                 UnitMode.DP -> {
@@ -189,7 +189,7 @@ private fun Measurement(
 
     Spacer(modifier = Modifier.height(8.dp))
     Column(modifier = Modifier.fillMaxWidth()) {
-        SectionTitle("Measurement")
+        SectionTitle("Distance")
         Spacer(modifier = Modifier.height(2.dp))
 
         MeasurementMetricBox(
@@ -404,23 +404,11 @@ private fun MeasurementMetricBox(
 }
 
 @Composable
-private fun BoxModel(
+private fun MarginPadding(
     selectionState: SelectionState,
     unitMode: UnitMode,
 ) {
     val density = LocalDensity.current.density
-    val size = remember(selectionState.properties.size, unitMode) {
-        val size = selectionState.properties.size
-        when (unitMode) {
-            UnitMode.DP -> {
-                "${(size.width / density).roundToInt()}dp x ${(size.height / density).roundToInt()}dp"
-            }
-
-            UnitMode.PX -> {
-                "${size.width}px x ${size.height}px"
-            }
-        }
-    }
 
     val margin = remember(selectionState.properties.margin, unitMode) {
         val margin = selectionState.properties.margin
@@ -438,6 +426,27 @@ private fun BoxModel(
                     add("${margin.top.roundToInt()}px")
                     add("${margin.right.roundToInt()}px")
                     add("${margin.bottom.roundToInt()}px")
+                }
+            }
+        }
+    }
+
+    val padding = remember(selectionState.properties.padding, unitMode) {
+        val padding = selectionState.properties.padding
+        buildList {
+            when (unitMode) {
+                UnitMode.DP -> {
+                    add("${(padding.left / density).roundToInt()}dp")
+                    add("${(padding.top / density).roundToInt()}dp")
+                    add("${(padding.right / density).roundToInt()}dp")
+                    add("${(padding.bottom / density).roundToInt()}dp")
+                }
+
+                UnitMode.PX -> {
+                    add("${padding.left.roundToInt()}px")
+                    add("${padding.top.roundToInt()}px")
+                    add("${padding.right.roundToInt()}px")
+                    add("${padding.bottom.roundToInt()}px")
                 }
             }
         }
@@ -471,14 +480,32 @@ private fun BoxModel(
                     Box(
                         modifier = Modifier
                             .weight(weight = 1.0f, fill = true)
-                            .fillMaxWidth(0.7f)
+                            .height(48.dp)
                             .padding(horizontal = 2.dp, vertical = 4.dp)
                             .border(1.dp, Color.Gray)
                             .background(Color(0xFFCCFFCC))
-                            .padding(horizontal = 4.dp, vertical = 8.dp),
-                        contentAlignment = Alignment.Center
+                            .padding(horizontal = 4.dp, vertical = 4.dp),
                     ) {
-                        Text(size, fontSize = 8.sp)
+                        Text(
+                            padding[1], // padding.top
+                            fontSize = 8.sp,
+                            modifier = Modifier.align(Alignment.TopCenter)
+                        )
+                        Text(
+                            padding[0], // padding.left
+                            fontSize = 8.sp,
+                            modifier = Modifier.align(Alignment.CenterStart)
+                        )
+                        Text(
+                            padding[2], // padding.right
+                            fontSize = 8.sp,
+                            modifier = Modifier.align(Alignment.CenterEnd)
+                        )
+                        Text(
+                            padding[3], // padding.bottom
+                            fontSize = 8.sp,
+                            modifier = Modifier.align(Alignment.BottomCenter)
+                        )
                     }
 
                     Spacer(modifier = Modifier.width(2.dp))
@@ -583,7 +610,9 @@ internal fun ElementDetailPreview() {
             type = UiNodeType.VIEW,
             id = "app:id/showDetail",
             size = android.util.Size(200, 100),
-            margin = RectF(11f, 10f, 5f, 5f),
+            distance = RectF(11f, 10f, 5f, 5f),
+            margin = RectF(16f, 16f, 16f, 16f),
+            padding = RectF(2f, 8f, 2f, 10f),
             actions = setOf(
                 UiNodeActionProperties.CLICKABLE
             ),

--- a/inspector-runtime/src/main/java/com/uhufor/inspector/ui/ElementDetails.kt
+++ b/inspector-runtime/src/main/java/com/uhufor/inspector/ui/ElementDetails.kt
@@ -1,4 +1,5 @@
 @file:OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
+
 package com.uhufor.inspector.ui
 
 import android.graphics.RectF
@@ -6,6 +7,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -13,6 +15,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -25,6 +28,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
@@ -83,6 +88,7 @@ internal fun ElementDetails(
             InfoRow("ID (${selectionState.properties.type.value})", selectionState.properties.id)
             InfoRow("Size", size)
 
+            Measurement(selectionState, unitMode)
             BoxModel(selectionState, unitMode)
             Actions(selectionState)
             Styles(selectionState)
@@ -140,7 +146,7 @@ private fun InfoRow(label: String, value: String) {
 }
 
 @Composable
-private fun BoxModel(
+private fun Measurement(
     selectionState: SelectionState,
     unitMode: UnitMode,
 ) {
@@ -182,6 +188,258 @@ private fun BoxModel(
     Spacer(modifier = Modifier.height(8.dp))
     Column(modifier = Modifier.fillMaxWidth()) {
         SectionTitle("Measurement")
+        Spacer(modifier = Modifier.height(2.dp))
+
+        MeasurementMetricBox(
+            {
+                Text(
+                    text = margin[0],
+                    fontSize = 8.sp,
+                    modifier = Modifier
+                        .background(Color(0xFFFFFFCC))
+                        .padding(1.dp)
+                        .align(Alignment.Center)
+                )
+            },
+            {
+                Text(
+                    text = margin[1],
+                    fontSize = 8.sp,
+                    modifier = Modifier
+                        .background(Color(0xFFFFFFCC))
+                        .padding(1.dp)
+                        .align(Alignment.Center)
+                )
+            },
+            {
+                Text(
+                    text = margin[2],
+                    fontSize = 8.sp,
+                    modifier = Modifier
+                        .background(Color(0xFFFFFFCC))
+                        .padding(1.dp)
+                        .align(Alignment.Center)
+                )
+            },
+            {
+                Text(
+                    text = margin[3],
+                    fontSize = 8.sp,
+                    modifier = Modifier
+                        .background(Color(0xFFFFFFCC))
+                        .padding(1.dp)
+                        .align(Alignment.Center)
+                )
+            },
+            {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                ) {
+                    Text(
+                        text = size,
+                        fontSize = 8.sp,
+                        modifier = Modifier
+                            .background(Color(0xFFCCFFCC))
+                            .padding(2.dp)
+                            .align(Alignment.Center)
+                    )
+                }
+            },
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    color = Color(0xCCFEFEFE),
+                    shape = RoundedCornerShape(2.dp)
+                )
+                .padding(4.dp)
+        )
+    }
+}
+
+@Composable
+private fun MeasurementMetricBox(
+    leftContent: @Composable BoxScope.() -> Unit,
+    topContent: @Composable BoxScope.() -> Unit,
+    rightContent: @Composable BoxScope.() -> Unit,
+    bottomContent: @Composable BoxScope.() -> Unit,
+    centerContent: @Composable BoxScope.() -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Box(modifier = Modifier.weight(1f))
+
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .heightIn(min = 24.dp)
+                    .drawBehind {
+                        val c = Color.Gray
+                        val stroke = 1.dp.toPx()
+                        val seg = 12.dp.toPx()
+                        val cx = size.width / 2f
+                        val x1 = (cx - seg / 2f).coerceIn(0f, size.width)
+                        val x2 = (cx + seg / 2f).coerceIn(0f, size.width)
+                        drawLine(c, Offset(cx, 0f), Offset(cx, size.height), strokeWidth = stroke)
+                        drawLine(c, Offset(x1, 0f), Offset(x2, 0f), strokeWidth = stroke)
+                    }
+            ) { topContent() }
+
+            Box(modifier = Modifier.weight(1f))
+        }
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Box(
+                modifier = Modifier
+                    .weight(0.5f)
+                    .heightIn(min = 24.dp)
+                    .drawBehind {
+                        val c = Color.Gray
+                        val stroke = 1.dp.toPx()
+                        val seg = 12.dp.toPx()
+                        val cy = size.height / 2f
+                        val y1 = (cy - seg / 2f).coerceIn(0f, size.height)
+                        val y2 = (cy + seg / 2f).coerceIn(0f, size.height)
+                        drawLine(c, Offset(0f, cy), Offset(size.width, cy), strokeWidth = stroke)
+                        drawLine(c, Offset(0f, y1), Offset(0f, y2), strokeWidth = stroke)
+                    }
+            ) { leftContent() }
+
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .heightIn(min = 24.dp)
+                    .drawBehind {
+                        val c = Color.Gray
+                        val stroke = 1.dp.toPx()
+                        val seg = 12.dp.toPx()
+                        val cx = size.width / 2f
+                        val cy = size.height / 2f
+                        val x1 = (cx - seg / 2f).coerceIn(0f, size.width)
+                        val x2 = (cx + seg / 2f).coerceIn(0f, size.width)
+                        val y1 = (cy - seg / 2f).coerceIn(0f, size.height)
+                        val y2 = (cy + seg / 2f).coerceIn(0f, size.height)
+                        drawLine(c, Offset(x1, 0f), Offset(x2, 0f), strokeWidth = stroke)
+                        drawLine(
+                            c,
+                            Offset(size.width, y1),
+                            Offset(size.width, y2),
+                            strokeWidth = stroke
+                        )
+                        drawLine(
+                            c,
+                            Offset(x1, size.height),
+                            Offset(x2, size.height),
+                            strokeWidth = stroke
+                        )
+                        drawLine(c, Offset(0f, y1), Offset(0f, y2), strokeWidth = stroke)
+                    }
+            ) { centerContent() }
+
+            Box(
+                modifier = Modifier
+                    .weight(0.5f)
+                    .heightIn(min = 24.dp)
+                    .drawBehind {
+                        val c = Color.Gray
+                        val stroke = 1.dp.toPx()
+                        val seg = 12.dp.toPx()
+                        val cy = size.height / 2f
+                        val y1 = (cy - seg / 2f).coerceIn(0f, size.height)
+                        val y2 = (cy + seg / 2f).coerceIn(0f, size.height)
+                        drawLine(c, Offset(0f, cy), Offset(size.width, cy), strokeWidth = stroke)
+                        drawLine(
+                            c,
+                            Offset(size.width, y1),
+                            Offset(size.width, y2),
+                            strokeWidth = stroke
+                        )
+                    }
+            ) { rightContent() }
+        }
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Box(modifier = Modifier.weight(1f))
+
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .heightIn(min = 24.dp)
+                    .drawBehind {
+                        val c = Color.Gray
+                        val stroke = 1.dp.toPx()
+                        val seg = 12.dp.toPx()
+                        val cx = size.width / 2f
+                        val x1 = (cx - seg / 2f).coerceIn(0f, size.width)
+                        val x2 = (cx + seg / 2f).coerceIn(0f, size.width)
+                        drawLine(c, Offset(cx, 0f), Offset(cx, size.height), strokeWidth = stroke)
+                        drawLine(
+                            c,
+                            Offset(x1, size.height),
+                            Offset(x2, size.height),
+                            strokeWidth = stroke
+                        )
+                    }
+            ) { bottomContent() }
+
+            Box(modifier = Modifier.weight(1f))
+        }
+    }
+}
+
+@Composable
+private fun BoxModel(
+    selectionState: SelectionState,
+    unitMode: UnitMode,
+) {
+    val density = LocalDensity.current.density
+    val size = remember(selectionState.properties.size, unitMode) {
+        val size = selectionState.properties.size
+        when (unitMode) {
+            UnitMode.DP -> {
+                "${(size.width / density).roundToInt()}dp x ${(size.height / density).roundToInt()}dp"
+            }
+
+            UnitMode.PX -> {
+                "${size.width}px x ${size.height}px"
+            }
+        }
+    }
+
+    val margin = remember(selectionState.properties.margin, unitMode) {
+        val margin = selectionState.properties.margin
+        buildList {
+            when (unitMode) {
+                UnitMode.DP -> {
+                    add("${(margin.left / density).roundToInt()}dp")
+                    add("${(margin.top / density).roundToInt()}dp")
+                    add("${(margin.right / density).roundToInt()}dp")
+                    add("${(margin.bottom / density).roundToInt()}dp")
+                }
+
+                UnitMode.PX -> {
+                    add("${margin.left.roundToInt()}px")
+                    add("${margin.top.roundToInt()}px")
+                    add("${margin.right.roundToInt()}px")
+                    add("${margin.bottom.roundToInt()}px")
+                }
+            }
+        }
+    }
+
+    Spacer(modifier = Modifier.height(8.dp))
+    Column(modifier = Modifier.fillMaxWidth()) {
+        SectionTitle("Margin / Padding")
         Spacer(modifier = Modifier.height(2.dp))
 
         Box(


### PR DESCRIPTION
* added margin and padding display to the property details view.
  * renamed the measurement property to distance.
    * applied a new design for distance.
  * displayed margin and padding values in the box model ui.